### PR TITLE
Add Deutscher Wetterdienst Provider (state run weather service in Germany)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +169,18 @@ checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
  "byteorder",
  "cipher",
+]
+
+[[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -298,6 +319,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7309d9b4d3d2c0641e018d449232f2e28f1b22933c137f157d3dbc14228b8c0e"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f47bf7270cf70d370f8f98c1abb6d2d4cf60a6845d30e05bfb90c6568650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "cookie"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +422,28 @@ dependencies = [
  "generic-array",
  "rand_core",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa 0.4.8",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -746,7 +809,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 1.0.5",
 ]
 
 [[package]]
@@ -803,7 +866,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 1.0.5",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -897,6 +960,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.42.0",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -1375,7 +1444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6fa99d535dd930d1249e6c79cb3c2915f9172a540fe2b02a4c8f9ca954721e"
 dependencies = [
  "dtoa",
- "itoa",
+ "itoa 1.0.5",
  "parking_lot",
  "prometheus-client-derive-encode",
 ]
@@ -1400,6 +1469,8 @@ dependencies = [
  "bcrypt",
  "clap",
  "clap-verbosity-flag",
+ "const_format",
+ "csv",
  "figment",
  "hex",
  "hmac",
@@ -1408,6 +1479,7 @@ dependencies = [
  "moka",
  "openssl",
  "prometheus-client",
+ "regex",
  "reqwest",
  "rocket",
  "rocket-basicauth",
@@ -1526,10 +1598,12 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -1868,7 +1942,7 @@ version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
- "itoa",
+ "itoa 1.0.5",
  "ryu",
  "serde",
 ]
@@ -1880,7 +1954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 1.0.5",
  "ryu",
  "serde",
 ]
@@ -2100,7 +2174,7 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
- "itoa",
+ "itoa 1.0.5",
  "libc",
  "num_threads",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aead"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14,12 +20,24 @@ dependencies = [
 
 [[package]]
 name = "aes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+dependencies = [
+ "cfg-if",
+ "cipher 0.3.0",
+ "cpufeatures",
+ "opaque-debug",
+]
+
+[[package]]
+name = "aes"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.3",
  "cpufeatures",
 ]
 
@@ -30,8 +48,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
 dependencies = [
  "aead",
- "aes",
- "cipher",
+ "aes 0.8.2",
+ "cipher 0.4.3",
  "ctr",
  "ghash",
  "subtle",
@@ -47,10 +65,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "assert-str"
@@ -100,6 +136,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +172,12 @@ name = "base64"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
+
+[[package]]
+name = "base64ct"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
 name = "bcrypt"
@@ -168,7 +219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
  "byteorder",
- "cipher",
+ "cipher 0.4.3",
 ]
 
 [[package]]
@@ -208,6 +259,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,12 +315,40 @@ name = "cc"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time 0.1.45",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "cipher"
@@ -308,6 +408,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "colored"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +449,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "cookie"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,7 +468,7 @@ dependencies = [
  "rand",
  "sha2",
  "subtle",
- "time",
+ "time 0.3.17",
  "version_check",
 ]
 
@@ -380,6 +496,21 @@ checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "critical-section"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
 name = "crossbeam-channel"
@@ -462,7 +593,51 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.3",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d1075c37807dcf850c379432f0df05ba52cc30f279c5cfc43cc221ce7f8579"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5044281f61b27bc598f2f6647d480aed48d2bf52d6eb0b627d84c0361b17aa70"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b50bc93ba22c27b0d31128d2d130a0a6b3d267ae27ef7e4fae2167dfe8781c"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e61fda7e62115119469c7b3591fd913ecca96fb766cfd3f2e2502ab7bc87a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -584,6 +759,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "float_next_after"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc612c5837986b7104a87a0df74a5460931f1c5274be12f8d0f40aa2f30d632"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +896,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "geo"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39f57e9624b1a17ce621375464e9878c705d0aaadaf25cb44e4e0005a16de2f"
+dependencies = [
+ "float_next_after",
+ "geo-types",
+ "geographiclib-rs",
+ "log",
+ "num-traits",
+ "robust",
+ "rstar",
+]
+
+[[package]]
+name = "geo-types"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26879b63ac36ca5492918dc16f8c1e604b0f70f884fffbd3533f89953ab1991"
+dependencies = [
+ "approx",
+ "num-traits",
+ "rstar",
+]
+
+[[package]]
+name = "geographiclib-rs"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a4efc8e99f43d1d29331a073981bb13074b253edc08ffc8ccf5f384b1d1d1e"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,10 +977,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heapless"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "spin 0.9.4",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -889,6 +1140,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +1249,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
+name = "jobserver"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,6 +1279,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
 name = "libsystemd"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,6 +1300,15 @@ dependencies = [
  "sha2",
  "thiserror",
  "uuid",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1098,6 +1397,15 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -1203,6 +1511,26 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1324,6 +1652,29 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
 ]
 
 [[package]]
@@ -1467,11 +1818,13 @@ dependencies = [
  "anyhow",
  "assert-str",
  "bcrypt",
+ "chrono",
  "clap",
  "clap-verbosity-flag",
  "const_format",
  "csv",
  "figment",
+ "geo",
  "hex",
  "hmac",
  "humantime-serde",
@@ -1490,6 +1843,7 @@ dependencies = [
  "systemd-journal-logger",
  "tokio",
  "toml",
+ "zip",
 ]
 
 [[package]]
@@ -1514,7 +1868,7 @@ dependencies = [
  "mach",
  "once_cell",
  "raw-cpuid",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -1684,6 +2038,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "robust"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5864e7ef1a6b7bcf1d6ca3f655e65e724ed3b52546a0d0a663c991522f552ea"
+
+[[package]]
 name = "rocket"
 version = "0.5.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1712,7 +2072,7 @@ dependencies = [
  "serde",
  "state",
  "tempfile",
- "time",
+ "time 0.3.17",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1772,10 +2132,21 @@ dependencies = [
  "smallvec",
  "stable-pattern",
  "state",
- "time",
+ "time 0.3.17",
  "tokio",
  "tokio-rustls",
  "uncased",
+]
+
+[[package]]
+name = "rstar"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b40f1bfe5acdab44bc63e6699c28b74f75ec43afb59f3eda01e145aff86a25fa"
+dependencies = [
+ "heapless",
+ "num-traits",
+ "smallvec",
 ]
 
 [[package]]
@@ -1875,6 +2246,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scratch"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+
+[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1960,6 +2337,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,7 +2385,7 @@ dependencies = [
  "atty",
  "colored",
  "log",
- "time",
+ "time 0.3.17",
  "windows-sys 0.42.0",
 ]
 
@@ -2052,6 +2440,9 @@ name = "spin"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "stable-pattern"
@@ -2061,6 +2452,12 @@ checksum = "4564168c00635f88eaed410d5efa8131afa8d8699a612c80c455a0ba05c21045"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state"
@@ -2166,6 +2563,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -2433,6 +2841,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2526,9 +2940,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -2816,3 +3230,53 @@ name = "zeroize"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+
+[[package]]
+name = "zip"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537ce7411d25e54e8ae21a7ce0b15840e7bfcff15b51d697ec3266cc76bdf080"
+dependencies = [
+ "aes 0.7.5",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time 0.3.17",
+ "zstd",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.5+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc50ffce891ad571e9f9afe5039c4837bede781ac4bb13052ed7ae695518596"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,15 +65,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,14 +322,9 @@ version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
- "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.45",
- "wasm-bindgen",
- "winapi",
 ]
 
 [[package]]
@@ -408,16 +394,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
 name = "colored"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,7 +444,7 @@ dependencies = [
  "rand",
  "sha2",
  "subtle",
- "time 0.3.17",
+ "time",
  "version_check",
 ]
 
@@ -594,50 +570,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher 0.4.3",
-]
-
-[[package]]
-name = "cxx"
-version = "1.0.86"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d1075c37807dcf850c379432f0df05ba52cc30f279c5cfc43cc221ce7f8579"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.86"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5044281f61b27bc598f2f6647d480aed48d2bf52d6eb0b627d84c0361b17aa70"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.86"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b50bc93ba22c27b0d31128d2d130a0a6b3d267ae27ef7e4fae2167dfe8781c"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.86"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e61fda7e62115119469c7b3591fd913ecca96fb766cfd3f2e2502ab7bc87a5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1140,30 +1072,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "winapi",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
-dependencies = [
- "cxx",
- "cxx-build",
-]
-
-[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,15 +1208,6 @@ dependencies = [
  "sha2",
  "thiserror",
  "uuid",
-]
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -2072,7 +1971,7 @@ dependencies = [
  "serde",
  "state",
  "tempfile",
- "time 0.3.17",
+ "time",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -2132,7 +2031,7 @@ dependencies = [
  "smallvec",
  "stable-pattern",
  "state",
- "time 0.3.17",
+ "time",
  "tokio",
  "tokio-rustls",
  "uncased",
@@ -2244,12 +2143,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "scratch"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "sct"
@@ -2385,7 +2278,7 @@ dependencies = [
  "atty",
  "colored",
  "log",
- "time 0.3.17",
+ "time",
  "windows-sys 0.42.0",
 ]
 
@@ -2563,17 +2456,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]
@@ -2839,12 +2721,6 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
@@ -3247,7 +3123,7 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "sha1",
- "time 0.3.17",
+ "time",
  "zstd",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1633,7 +1633,6 @@ dependencies = [
  "moka",
  "openssl",
  "prometheus-client",
- "regex",
  "reqwest",
  "rocket",
  "rocket-basicauth",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,24 +20,12 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
-dependencies = [
- "cfg-if",
- "cipher 0.3.0",
- "cpufeatures",
- "opaque-debug",
-]
-
-[[package]]
-name = "aes"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
  "cfg-if",
- "cipher 0.4.3",
+ "cipher",
  "cpufeatures",
 ]
 
@@ -48,20 +36,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
 dependencies = [
  "aead",
- "aes 0.8.2",
- "cipher 0.4.3",
+ "aes",
+ "cipher",
  "ctr",
  "ghash",
  "subtle",
-]
-
-[[package]]
-name = "aho-corasick"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -165,12 +144,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
-name = "base64ct"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
-
-[[package]]
 name = "bcrypt"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,7 +183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
  "byteorder",
- "cipher 0.4.3",
+ "cipher",
 ]
 
 [[package]]
@@ -250,27 +223,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "camino"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,9 +258,6 @@ name = "cc"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cfg-if"
@@ -325,15 +274,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
-]
-
-[[package]]
-name = "cipher"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -423,12 +363,6 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cookie"
@@ -569,7 +503,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher 0.4.3",
+ "cipher",
 ]
 
 [[package]]
@@ -1157,15 +1091,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
-name = "jobserver"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,29 +1479,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest",
- "hmac",
- "password-hash",
- "sha2",
-]
-
-[[package]]
 name = "pear"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1855,8 +1757,6 @@ version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax",
 ]
 
@@ -2227,17 +2127,6 @@ dependencies = [
  "itoa 1.0.5",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]
@@ -3113,46 +3002,8 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537ce7411d25e54e8ae21a7ce0b15840e7bfcff15b51d697ec3266cc76bdf080"
 dependencies = [
- "aes 0.7.5",
  "byteorder",
- "bzip2",
- "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
  "flate2",
- "hmac",
- "pbkdf2",
- "sha1",
- "time",
- "zstd",
-]
-
-[[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.5+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc50ffce891ad571e9f9afe5039c4837bede781ac4bb13052ed7ae695518596"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ rocket-basicauth = "2.1.1"
 bcrypt = "0.13.0"
 openssl = { version = "0.10.45", features = ["vendored"] }
 simple_logger = { version = "4.0.0", features = ["timestamps", "colors", "stderr"] }
+csv = "1.1.6"
+const_format = "0.2.30"
+regex = "1.7.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 systemd-journal-logger = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ csv = "1.1.6"
 const_format = "0.2.30"
 regex = "1.7.1"
 geo = "0.23.1"
-chrono = { version = "0.4.23", features = ["serde"] }
+chrono = { version = "0.4.23", default-features = false, features = ["serde"] }
 zip = "0.6.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ simple_logger = { version = "4.0.0", features = ["timestamps", "colors", "stderr
 csv = "1.1.6"
 const_format = "0.2.30"
 regex = "1.7.1"
+geo = "0.23.1"
+chrono = { version = "0.4.23", features = ["serde"] }
+zip = "0.6.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 systemd-journal-logger = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ openssl = { version = "0.10.45", features = ["vendored"] }
 simple_logger = { version = "4.0.0", features = ["timestamps", "colors", "stderr"] }
 csv = "1.1.6"
 const_format = "0.2.30"
-regex = { version = "1.7.1", default-features = false, features = ["std"] }
 geo = "0.23.1"
 chrono = { version = "0.4.23", default-features = false, features = ["serde"] }
 zip = { version = "0.6.3", default-features = false, features = ["deflate-miniz"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,10 @@ openssl = { version = "0.10.45", features = ["vendored"] }
 simple_logger = { version = "4.0.0", features = ["timestamps", "colors", "stderr"] }
 csv = "1.1.6"
 const_format = "0.2.30"
-regex = "1.7.1"
+regex = { version = "1.7.1", default-features = false, features = ["std"] }
 geo = "0.23.1"
 chrono = { version = "0.4.23", default-features = false, features = ["serde"] }
-zip = "0.6.3"
+zip = { version = "0.6.3", default-features = false, features = ["deflate-miniz"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 systemd-journal-logger = "0.7.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use crate::providers::cache::RequestBody;
 use crate::providers::units::Coordinates;
 use crate::providers::{Providers, WeatherProvider, WeatherRequest};
 use anyhow::Context;
@@ -6,7 +7,6 @@ use figment::{
     Figment,
 };
 use log::{debug, info, warn, Level};
-use moka::sync::Cache;
 use rocket::config::Ident;
 use rocket::figment::providers::Serialized;
 use rocket::serde::Serialize;
@@ -102,7 +102,7 @@ pub type ProviderTasks = Vec<Task>;
 pub struct Task {
     pub provider: Arc<dyn WeatherProvider + Send + Sync>,
     pub request: WeatherRequest<Coordinates>,
-    pub cache: Cache<String, String>,
+    pub cache: RequestBody,
 }
 
 pub fn get_provider_tasks(config: Config) -> anyhow::Result<ProviderTasks> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -113,7 +113,8 @@ pub fn get_provider_tasks(config: Config) -> anyhow::Result<ProviderTasks> {
     let mut tasks: ProviderTasks = vec![];
 
     for configured_provider in configured_providers {
-        let cache = moka::sync::CacheBuilder::new(config.locations.len() as u64)
+        let max_capacity = config.locations.len() * configured_provider.cache_cardinality();
+        let cache = moka::sync::CacheBuilder::new(max_capacity as u64)
             .time_to_live(configured_provider.refresh_interval())
             .build();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
-use crate::providers::cache::RequestBody;
 use crate::providers::units::Coordinates;
+use crate::providers::HttpRequestBodyCache;
 use crate::providers::{Providers, WeatherProvider, WeatherRequest};
 use anyhow::Context;
 use figment::{
@@ -102,7 +102,7 @@ pub type ProviderTasks = Vec<Task>;
 pub struct Task {
     pub provider: Arc<dyn WeatherProvider + Send + Sync>,
     pub request: WeatherRequest<Coordinates>,
-    pub cache: RequestBody,
+    pub cache: HttpRequestBodyCache,
 }
 
 pub fn get_provider_tasks(config: Config) -> anyhow::Result<ProviderTasks> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
-use crate::providers::{Coordinates, Providers, WeatherProvider, WeatherRequest};
+use crate::providers::units::Coordinates;
+use crate::providers::{Providers, WeatherProvider, WeatherRequest};
 use anyhow::Context;
 use figment::{
     providers::{Env, Format, Toml},

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use crate::providers::units::Coordinates;
 use crate::providers::HttpRequestBodyCache;
 use crate::providers::{Providers, WeatherProvider, WeatherRequest};
 use anyhow::Context;
+use const_format::concatcp;
 use figment::{
     providers::{Env, Format, Toml},
     Figment,
@@ -19,7 +20,7 @@ use std::time::Duration;
 
 pub const NAME: &str = env!("CARGO_PKG_NAME");
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
-pub const DEFAULT_CONFIG: &str = concat!("/etc/", env!("CARGO_PKG_NAME"), "/weathermen.toml");
+pub const DEFAULT_CONFIG: &str = concatcp!("/etc/", NAME, "/weathermen.toml");
 const DEFAULT_PORT: u16 = 36333;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -85,7 +85,7 @@ mod tests {
                 r##"# HELP weather_temperature_celsius prometheus-weathermen temperature.
 # TYPE weather_temperature_celsius gauge
 # UNIT weather_temperature_celsius celsius
-weather_temperature_celsius{{version="{0}",source="org.example",location="My Name",city="Some City",latitude="20.1000004",longitude="10.0123396"}} 25.5
+weather_temperature_celsius{{version="{0}",source="org.example",location="My Name",city="Some City",latitude="20.1000000",longitude="10.0123400"}} 25.5
 # EOF
 "##,
                 crate::config::VERSION
@@ -112,11 +112,11 @@ weather_temperature_celsius{{version="{0}",source="org.example",location="My Nam
                 r##"# HELP weather_temperature_celsius prometheus-weathermen temperature.
 # TYPE weather_temperature_celsius gauge
 # UNIT weather_temperature_celsius celsius
-weather_temperature_celsius{{version="{0}",source="org.example",location="My Name",city="Some City",latitude="20.1000004",longitude="10.0123396"}} 25.5
+weather_temperature_celsius{{version="{0}",source="org.example",location="My Name",city="Some City",latitude="20.1000000",longitude="10.0123400"}} 25.5
 # HELP weather_relative_humidity_ratio prometheus-weathermen relative humidity.
 # TYPE weather_relative_humidity_ratio gauge
 # UNIT weather_relative_humidity_ratio ratio
-weather_relative_humidity_ratio{{version="{0}",source="org.example",location="My Name",city="Some City",latitude="20.1000004",longitude="10.0123396"}} 0.55
+weather_relative_humidity_ratio{{version="{0}",source="org.example",location="My Name",city="Some City",latitude="20.1000000",longitude="10.0123400"}} 0.55
 # EOF
 "##,
                 crate::config::VERSION

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -73,9 +73,9 @@ pub fn format(weathers: Vec<Weather>) -> anyhow::Result<String> {
 #[cfg(test)]
 mod tests {
     use crate::prometheus::format;
-    use crate::providers::units::Celsius;
     use crate::providers::units::Ratio::Ratio;
-    use crate::providers::{Coordinate, Coordinates, Weather};
+    use crate::providers::units::{Celsius, Coordinate, Coordinates};
+    use crate::providers::Weather;
     use assert_str::assert_str_eq;
 
     #[test]

--- a/src/providers/cache.rs
+++ b/src/providers/cache.rs
@@ -1,3 +1,4 @@
+use crate::providers::HttpRequestBodyCache;
 use log::{debug, trace};
 use moka::sync::Cache;
 use reqwest::blocking::Client;
@@ -5,6 +6,8 @@ use reqwest::{Method, Url};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
+
+pub type HttpRequestBody = Cache<(Method, Url), String>;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Configuration {
@@ -17,11 +20,9 @@ const fn default_refresh_interval() -> Duration {
     Duration::from_secs(60 * 10)
 }
 
-pub type RequestBody = Cache<(Method, Url), String>;
-
 pub fn reqwest_cached_body_json<T: DeserializeOwned + std::fmt::Debug>(
     source: &str,
-    cache: &RequestBody,
+    cache: &HttpRequestBodyCache,
     client: &Client,
     method: Method,
     url: Url,
@@ -40,7 +41,7 @@ pub fn reqwest_cached_body_json<T: DeserializeOwned + std::fmt::Debug>(
 
 pub fn reqwest_cached_body(
     source: &str,
-    cache: &RequestBody,
+    cache: &HttpRequestBodyCache,
     client: &Client,
     method: Method,
     url: Url,

--- a/src/providers/deutscher_wetterdienst.rs
+++ b/src/providers/deutscher_wetterdienst.rs
@@ -100,6 +100,7 @@ fn find_closest_weather_station<'a>(
     }
 }
 
+#[allow(clippy::case_sensitive_file_extension_comparisons)]
 fn is_measurement_file(file_name: &str) -> bool {
     file_name.starts_with("produkt_zehn_now") && file_name.ends_with(".txt")
 }

--- a/src/providers/deutscher_wetterdienst.rs
+++ b/src/providers/deutscher_wetterdienst.rs
@@ -20,7 +20,7 @@ const BASE_URL: &str = "https://opendata.dwd.de/climate_environment/CDC/observat
 const STATION_LIST_URL: &str = concatcp!(BASE_URL, "/zehn_now_tu_Beschreibung_Stationen.txt");
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct Dwd {
+pub struct DeutscherWetterdienst {
     #[serde(flatten)]
     pub cache: Configuration,
 }
@@ -187,7 +187,7 @@ fn reqwest_cached_measurement_csv(
     Ok(csv)
 }
 
-impl WeatherProvider for Dwd {
+impl WeatherProvider for DeutscherWetterdienst {
     fn id(&self) -> &str {
         SOURCE_URI
     }
@@ -241,7 +241,7 @@ impl WeatherProvider for Dwd {
 
 #[cfg(test)]
 mod tests {
-    use crate::providers::dwd::{
+    use crate::providers::deutscher_wetterdienst::{
         find_closest_weather_station, parse_weather_station_list_csv, WeatherStation,
     };
     use crate::providers::units::Coordinates;

--- a/src/providers/deutscher_wetterdienst.rs
+++ b/src/providers/deutscher_wetterdienst.rs
@@ -229,7 +229,7 @@ impl WeatherProvider for DeutscherWetterdienst {
 
         let stations = parse_weather_station_list_csv(&station_csv);
         let closest_station = find_closest_weather_station(&request.query, &stations)?;
-        trace!("Found closest weather stations {:?}", closest_station);
+        trace!("Found closest weather station {:?}", closest_station);
         let measurement_csv =
             reqwest_cached_measurement_csv(cache, &client, &closest_station.station_id)?;
         let measurements = parse_measurement_data_csv(&measurement_csv);

--- a/src/providers/dwd.rs
+++ b/src/providers/dwd.rs
@@ -1,6 +1,6 @@
-use crate::providers::cache::{reqwest_cached_body, Configuration, RequestBody};
+use crate::providers::cache::{reqwest_cached_body, Configuration};
 use crate::providers::units::{Celsius, Coordinate, Coordinates, Ratio};
-use crate::providers::{Weather, WeatherProvider, WeatherRequest};
+use crate::providers::{HttpRequestBodyCache, Weather, WeatherProvider, WeatherRequest};
 use anyhow::anyhow;
 use chrono::Utc;
 use const_format::concatcp;
@@ -160,7 +160,7 @@ fn parse_measurement_data_csv(data: &String) -> Vec<Measurement> {
 }
 
 fn reqwest_cached_measurement_csv(
-    cache: &RequestBody,
+    cache: &HttpRequestBodyCache,
     client: &Client,
     station_id: &String,
 ) -> anyhow::Result<String> {
@@ -195,7 +195,7 @@ impl WeatherProvider for Dwd {
 
     fn for_coordinates(
         &self,
-        cache: &RequestBody,
+        cache: &HttpRequestBodyCache,
         request: &WeatherRequest<Coordinates>,
     ) -> anyhow::Result<Weather> {
         let client = Client::new();

--- a/src/providers/dwd.rs
+++ b/src/providers/dwd.rs
@@ -178,6 +178,7 @@ impl WeatherProvider for Dwd {
         let stations = parse_weather_station_list_csv(&station_csv);
         let closest_station = find_closest_weather_station(&request.query, &stations)?;
 
+        // TODO: caching
         let zip = client
             .request(
                 Method::GET,

--- a/src/providers/dwd.rs
+++ b/src/providers/dwd.rs
@@ -1,0 +1,70 @@
+use crate::providers::cache::{reqwest_cached_body, Configuration, RequestBody};
+use crate::providers::units::Coordinates;
+use crate::providers::{Weather, WeatherProvider, WeatherRequest};
+use const_format::concatcp;
+use csv::Trim;
+use log::debug;
+use reqwest::blocking::Client;
+use reqwest::{Method, Url};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Dwd {
+    #[serde(flatten)]
+    pub cache: Configuration,
+}
+
+const SOURCE_URI: &str = "de.dwd";
+
+const BASE_URL: &str = "https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate/10_minutes/air_temperature/recent/";
+const METADATA_URL: &str = concatcp!(BASE_URL, "zehn_min_tu_Beschreibung_Stationen.txt");
+
+impl WeatherProvider for Dwd {
+    fn id(&self) -> &str {
+        SOURCE_URI
+    }
+
+    fn for_coordinates(
+        &self,
+        cache: &RequestBody,
+        request: &WeatherRequest<Coordinates>,
+    ) -> anyhow::Result<Weather> {
+        let client = Client::new();
+
+        let re = regex::Regex::new(r"[ ]+")?;
+
+        let metadata = reqwest_cached_body(
+            SOURCE_URI,
+            cache,
+            &client,
+            Method::GET,
+            Url::parse(METADATA_URL)?,
+            Some("iso-8859-15"),
+        )?;
+
+        let metadata_clean = re.replace_all(&metadata, " ");
+
+        debug!("{}", metadata_clean);
+
+        let mut reader = csv::ReaderBuilder::new()
+            .delimiter(b' ')
+            .double_quote(false)
+            .comment(Some(b'-'))
+            .trim(Trim::All)
+            .flexible(true)
+            .from_reader(metadata_clean.as_bytes());
+        for result in reader.records() {
+            // The iterator yields Result<StringRecord, Error>, so we check the
+            // error here.
+            let record = result?;
+            println!("{:?}", record);
+        }
+
+        todo!()
+    }
+
+    fn refresh_interval(&self) -> Duration {
+        self.cache.refresh_interval
+    }
+}

--- a/src/providers/dwd.rs
+++ b/src/providers/dwd.rs
@@ -107,21 +107,20 @@ fn read_measurement_data_zip(buf: &[u8]) -> anyhow::Result<String> {
 
 #[derive(Deserialize, Debug, Clone)]
 struct Measurement {
-    // ;MESS_DATUM;  QN;PP_10;TT_10;TM5_10;RF_10;TD_10;eor
     #[serde(rename = "STATIONS_ID")]
-    station_id: String,
+    _station_id: String,
     #[serde(rename = "MESS_DATUM", with = "minute_precision_date_format")]
-    time: chrono::DateTime<Utc>,
+    _time: chrono::DateTime<Utc>,
     #[serde(rename = "PP_10")]
-    atmospheric_pressure: String,
+    _atmospheric_pressure: String,
     #[serde(rename = "TT_10")]
     temperature_200_centimers: Celsius,
     #[serde(rename = "TM5_10")]
-    temperature_5_centimeters: Celsius,
+    _temperature_5_centimeters: Celsius,
     #[serde(rename = "RF_10")]
     relative_humidity_200_centimeters: Ratio,
     #[serde(rename = "TD_10")]
-    dew_point_temperature_200_centimeters: Celsius,
+    _dew_point_temperature_200_centimeters: Celsius,
 }
 
 mod minute_precision_date_format {

--- a/src/providers/dwd.rs
+++ b/src/providers/dwd.rs
@@ -166,8 +166,7 @@ fn reqwest_cached_measurement_csv(
 ) -> anyhow::Result<String> {
     let method = Method::GET;
     let url = Url::parse(&format!(
-        "{}/10minutenwerte_TU_{}_now.zip",
-        BASE_URL, station_id
+        "{BASE_URL}/10minutenwerte_TU_{station_id}_now.zip"
     ))?;
 
     let key = (method.clone(), url.clone());

--- a/src/providers/dwd.rs
+++ b/src/providers/dwd.rs
@@ -55,10 +55,10 @@ fn parse_weather_station_list_csv(data: &str) -> Vec<WeatherStation> {
         .collect::<Vec<WeatherStation>>()
 }
 
-fn find_closest_weather_station<'a, 'b>(
-    coords: &'a Coordinates,
-    weather_stations: &'b [WeatherStation],
-) -> anyhow::Result<&'b WeatherStation> {
+fn find_closest_weather_station<'a>(
+    coords: &Coordinates,
+    weather_stations: &'a [WeatherStation],
+) -> anyhow::Result<&'a WeatherStation> {
     let point: Point<f64> = Point::new(
         coords.longitude.clone().into(),
         coords.latitude.clone().into(),

--- a/src/providers/dwd.rs
+++ b/src/providers/dwd.rs
@@ -1,13 +1,21 @@
 use crate::providers::cache::{reqwest_cached_body, Configuration, RequestBody};
-use crate::providers::units::Coordinates;
+use crate::providers::units::{Celsius, Coordinate, Coordinates, Ratio};
 use crate::providers::{Weather, WeatherProvider, WeatherRequest};
+use anyhow::anyhow;
+use chrono::Utc;
 use const_format::concatcp;
 use csv::Trim;
+use geo::{Closest, ClosestPoint, Point};
 use log::debug;
+use regex::Regex;
 use reqwest::blocking::Client;
 use reqwest::{Method, Url};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
+
+const SOURCE_URI: &str = "de.dwd";
+const BASE_URL: &str = "https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate/10_minutes/air_temperature/now";
+const STATION_LIST_URL: &str = concatcp!(BASE_URL, "/zehn_now_tu_Beschreibung_Stationen.txt");
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Dwd {
@@ -15,10 +23,136 @@ pub struct Dwd {
     pub cache: Configuration,
 }
 
-const SOURCE_URI: &str = "de.dwd";
+#[derive(Deserialize, Debug, PartialEq, Clone)]
+struct WeatherStation {
+    #[serde(rename = "Stations_id")]
+    station_id: String,
+    #[serde(rename = "Stationsname")]
+    name: String,
+    #[serde(rename = "geoBreite")]
+    latitude: Coordinate,
+    #[serde(rename = "geoLaenge")]
+    longitude: Coordinate,
+}
 
-const BASE_URL: &str = "https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate/10_minutes/air_temperature/recent/";
-const METADATA_URL: &str = concatcp!(BASE_URL, "zehn_min_tu_Beschreibung_Stationen.txt");
+fn parse_weather_station_list_csv(data: &str) -> Vec<WeatherStation> {
+    let re = Regex::new(r"[ ]+").expect("Hardcoded, so always works");
+    let clean_data = re.replace_all(data, " ");
+
+    let reader = csv::ReaderBuilder::new()
+        .delimiter(b' ')
+        .double_quote(false)
+        .comment(Some(b'-'))
+        .trim(Trim::All)
+        .flexible(true)
+        .from_reader(clean_data.as_bytes());
+
+    reader
+        .into_deserialize::<WeatherStation>()
+        .map(|m| m.expect("Should always succeed"))
+        .collect::<Vec<WeatherStation>>()
+}
+
+fn find_closest_weather_station<'a, 'b>(
+    coords: &'a Coordinates,
+    weather_stations: &'b [WeatherStation],
+) -> anyhow::Result<&'b WeatherStation> {
+    let point: geo::Point<f64> = Point::new(
+        coords.longitude.clone().into(),
+        coords.latitude.clone().into(),
+    );
+    let points = geo::MultiPoint::new(
+        weather_stations
+            .iter()
+            .map(|s| Point::new(s.longitude.clone().into(), s.latitude.clone().into()))
+            .collect(),
+    );
+
+    match points.closest_point(&point) {
+        Closest::SinglePoint(point) | Closest::Intersection(point) => {
+            let matching_station = weather_stations
+                .iter()
+                .find(|s| s.longitude == point.x().into() && s.latitude == point.y().into())
+                .expect("Must be able to find matching weather station");
+
+            Ok(matching_station)
+        }
+        Closest::Indeterminate => Err(anyhow!("Could not find closest point")),
+    }
+}
+
+fn read_measurement_data_zip(buf: &[u8]) -> anyhow::Result<String> {
+    use std::io::prelude::*;
+    let reader = std::io::Cursor::new(buf);
+    let mut zip = zip::ZipArchive::new(reader)?;
+
+    let re = Regex::new(r"^produkt_zehn_now_tu_.*\.txt$").expect("Hardcoded, so always works");
+
+    for i in 0..zip.len() {
+        let mut file = zip.by_index(i)?;
+
+        if !re.is_match(file.name()) {
+            continue;
+        }
+
+        debug!("Found file name in measurement data zip: {}", file.name());
+
+        let mut buf: String = String::new();
+        file.read_to_string(&mut buf)?;
+
+        return Ok(buf);
+    }
+    Err(anyhow!("Could not find weather data file in ZIP archive"))
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct Measurement {
+    // ;MESS_DATUM;  QN;PP_10;TT_10;TM5_10;RF_10;TD_10;eor
+    #[serde(rename = "STATIONS_ID")]
+    station_id: String,
+    #[serde(rename = "MESS_DATUM", with = "minute_precision_date_format")]
+    time: chrono::DateTime<Utc>,
+    #[serde(rename = "PP_10")]
+    atmospheric_pressure: String,
+    #[serde(rename = "TT_10")]
+    temperature_200_centimers: Celsius,
+    #[serde(rename = "TM5_10")]
+    temperature_5_centimeters: Celsius,
+    #[serde(rename = "RF_10")]
+    relative_humidity_200_centimeters: Ratio,
+    #[serde(rename = "TD_10")]
+    dew_point_temperature_200_centimeters: Celsius,
+}
+
+mod minute_precision_date_format {
+    use chrono::{DateTime, TimeZone, Utc};
+    use serde::{self, Deserialize, Deserializer};
+
+    const FORMAT: &str = "%Y%m%d%H%M";
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Utc.datetime_from_str(&s, FORMAT)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+fn parse_measurement_data_csv(data: &String) -> Vec<Measurement> {
+    debug!("parse_weather_station_data_csv");
+    let reader = csv::ReaderBuilder::new()
+        .delimiter(b';')
+        .double_quote(false)
+        .trim(Trim::All)
+        .from_reader(data.as_bytes());
+
+    reader
+        .into_deserialize::<Measurement>()
+        .map(|m| m.expect("Should always succeed"))
+        .collect::<Vec<Measurement>>()
+}
 
 impl WeatherProvider for Dwd {
     fn id(&self) -> &str {
@@ -32,39 +166,103 @@ impl WeatherProvider for Dwd {
     ) -> anyhow::Result<Weather> {
         let client = Client::new();
 
-        let re = regex::Regex::new(r"[ ]+")?;
-
-        let metadata = reqwest_cached_body(
+        let station_csv = reqwest_cached_body(
             SOURCE_URI,
             cache,
             &client,
             Method::GET,
-            Url::parse(METADATA_URL)?,
+            Url::parse(STATION_LIST_URL)?,
             Some("iso-8859-15"),
         )?;
 
-        let metadata_clean = re.replace_all(&metadata, " ");
+        let stations = parse_weather_station_list_csv(&station_csv);
+        let closest_station = find_closest_weather_station(&request.query, &stations)?;
 
-        debug!("{}", metadata_clean);
+        let zip = client
+            .request(
+                Method::GET,
+                Url::parse(&format!(
+                    "{}/10minutenwerte_TU_{}_now.zip",
+                    BASE_URL, closest_station.station_id
+                ))?,
+            )
+            .send()?
+            .bytes();
 
-        let mut reader = csv::ReaderBuilder::new()
-            .delimiter(b' ')
-            .double_quote(false)
-            .comment(Some(b'-'))
-            .trim(Trim::All)
-            .flexible(true)
-            .from_reader(metadata_clean.as_bytes());
-        for result in reader.records() {
-            // The iterator yields Result<StringRecord, Error>, so we check the
-            // error here.
-            let record = result?;
-            println!("{:?}", record);
-        }
+        let weather_info_csv = read_measurement_data_zip(&zip?)?;
+        let measurements = parse_measurement_data_csv(&weather_info_csv);
+        let measurement = measurements.last().expect("Taking last measurement info");
 
-        todo!()
+        debug!("Found last measurement: {:?}", measurement.clone());
+
+        Ok(Weather {
+            source: SOURCE_URI.into(),
+            location: request.name.clone(),
+            city: closest_station.name.clone(),
+            coordinates: Coordinates {
+                latitude: closest_station.latitude.clone(),
+                longitude: closest_station.longitude.clone(),
+            },
+            temperature: measurement.temperature_200_centimers,
+            relative_humidity: Some(measurement.relative_humidity_200_centimeters),
+        })
     }
 
     fn refresh_interval(&self) -> Duration {
         self.cache.refresh_interval
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::providers::dwd::{
+        find_closest_weather_station, parse_weather_station_list_csv, WeatherStation,
+    };
+    use crate::providers::units::Coordinates;
+
+    #[test]
+    fn parse_csv() -> () {
+        assert_eq!(vec![WeatherStation {
+            station_id: "00044".into(),
+            name: "Großenkneten".into(),
+            latitude: 52.9336.into(),
+            longitude: 8.2370.into(),
+        }], parse_weather_station_list_csv(&"Stations_id von_datum bis_datum Stationshoehe geoBreite geoLaenge Stationsname Bundesland\n\
+----------- --------- --------- ------------- --------- --------- ----------------------------------------- ----------\n\
+00044 20070209 20230111             44     52.9336    8.2370 Großenkneten                             Niedersachsen                                                                                     \n\
+".to_string()));
+    }
+
+    #[test]
+    fn find_closest() -> () {
+        assert_eq!(
+            &WeatherStation {
+                station_id: "03379".into(),
+                name: "München-Stadt".into(),
+                latitude: 48.1632.into(),
+                longitude: 11.5429.into(),
+            },
+            find_closest_weather_station(
+                &Coordinates {
+                    latitude: 48.11591.into(),
+                    longitude: 11.570906.into(),
+                },
+                &vec![
+                    WeatherStation {
+                        station_id: "03379".into(),
+                        name: "München-Stadt".into(),
+                        latitude: 48.1632.into(),
+                        longitude: 11.5429.into(),
+                    },
+                    WeatherStation {
+                        station_id: "01262".into(),
+                        name: "München-Flughafen".into(),
+                        latitude: 48.3477.into(),
+                        longitude: 11.8134.into(),
+                    },
+                ]
+            )
+            .expect("Should find something")
+        );
     }
 }

--- a/src/providers/dwd.rs
+++ b/src/providers/dwd.rs
@@ -87,7 +87,7 @@ fn read_measurement_data_zip(buf: &[u8]) -> anyhow::Result<String> {
     let reader = Cursor::new(buf);
     let mut zip = ZipArchive::new(reader)?;
 
-    let re = Regex::new(r"^produkt_zehn_now_tu_\d{8}_\d{8}_.+\.txt$")
+    let re = Regex::new(r"^produkt_zehn_now_tu_[0-9]{8}_[0-9]{8}_.+\.txt$")
         .expect("Hardcoded, so always works");
 
     for i in 0..zip.len() {

--- a/src/providers/meteoblue.rs
+++ b/src/providers/meteoblue.rs
@@ -1,6 +1,6 @@
-use crate::providers::cache::{reqwest_cached_body_json, Configuration, RequestBody};
+use crate::providers::cache::{reqwest_cached_body_json, Configuration};
 use crate::providers::units::{Celsius, Coordinates};
-use crate::providers::{Weather, WeatherProvider, WeatherRequest};
+use crate::providers::{HttpRequestBodyCache, Weather, WeatherProvider, WeatherRequest};
 use anyhow::Context;
 use hmac::{Hmac, Mac};
 use reqwest::{Method, Url};
@@ -45,7 +45,7 @@ impl WeatherProvider for Meteoblue {
 
     fn for_coordinates(
         &self,
-        cache: &RequestBody,
+        cache: &HttpRequestBodyCache,
         request: &WeatherRequest<Coordinates>,
     ) -> anyhow::Result<Weather> {
         let url = Url::parse_with_params(

--- a/src/providers/meteoblue.rs
+++ b/src/providers/meteoblue.rs
@@ -1,6 +1,6 @@
 use crate::providers::cache::{reqwest_cached_body_json, Configuration};
-use crate::providers::units::Celsius;
-use crate::providers::{Coordinates, Weather, WeatherProvider, WeatherRequest};
+use crate::providers::units::{Celsius, Coordinates};
+use crate::providers::{Weather, WeatherProvider, WeatherRequest};
 use anyhow::Context;
 use hmac::{Hmac, Mac};
 use moka::sync::Cache;

--- a/src/providers/meteoblue.rs
+++ b/src/providers/meteoblue.rs
@@ -1,9 +1,8 @@
-use crate::providers::cache::{reqwest_cached_body_json, Configuration};
+use crate::providers::cache::{reqwest_cached_body_json, Configuration, RequestBody};
 use crate::providers::units::{Celsius, Coordinates};
 use crate::providers::{Weather, WeatherProvider, WeatherRequest};
 use anyhow::Context;
 use hmac::{Hmac, Mac};
-use moka::sync::Cache;
 use reqwest::{Method, Url};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
@@ -46,7 +45,7 @@ impl WeatherProvider for Meteoblue {
 
     fn for_coordinates(
         &self,
-        cache: &Cache<String, String>,
+        cache: &RequestBody,
         request: &WeatherRequest<Coordinates>,
     ) -> anyhow::Result<Weather> {
         let url = Url::parse_with_params(
@@ -81,6 +80,7 @@ impl WeatherProvider for Meteoblue {
             &client,
             Method::GET,
             signed_url,
+            None,
         )?;
 
         Ok(Weather {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,12 +1,12 @@
 mod cache;
-mod dwd;
+mod deutscher_wetterdienst;
 mod meteoblue;
 mod nogoodnik;
 mod open_weather;
 mod tomorrow;
 pub mod units;
 
-use crate::providers::dwd::Dwd;
+use crate::providers::deutscher_wetterdienst::DeutscherWetterdienst;
 use crate::providers::meteoblue::Meteoblue;
 use crate::providers::nogoodnik::Nogoodnik;
 use crate::providers::open_weather::OpenWeather;
@@ -23,7 +23,7 @@ pub struct Providers {
     open_weather: Option<OpenWeather>,
     meteoblue: Option<Meteoblue>,
     tomorrow: Option<Tomorrow>,
-    dwd: Option<Dwd>,
+    deutscher_wetterdienst: Option<DeutscherWetterdienst>,
     nogoodnik: Option<Nogoodnik>,
 }
 
@@ -46,7 +46,7 @@ impl IntoIterator for Providers {
             vec.push(Arc::new(provider));
         }
 
-        if let Some(provider) = self.dwd {
+        if let Some(provider) = self.deutscher_wetterdienst {
             vec.push(Arc::new(provider));
         }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,16 +1,18 @@
-mod cache;
+pub mod cache;
+mod dwd;
 mod meteoblue;
 mod nogoodnik;
 mod open_weather;
 mod tomorrow;
 pub mod units;
 
+use crate::providers::cache::RequestBody;
+use crate::providers::dwd::Dwd;
 use crate::providers::meteoblue::Meteoblue;
 use crate::providers::nogoodnik::Nogoodnik;
 use crate::providers::open_weather::OpenWeather;
 use crate::providers::tomorrow::Tomorrow;
 use crate::providers::units::{Celsius, Ratio};
-use moka::sync::Cache;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
@@ -22,6 +24,7 @@ pub struct Providers {
     open_weather: Option<OpenWeather>,
     meteoblue: Option<Meteoblue>,
     tomorrow: Option<Tomorrow>,
+    dwd: Option<Dwd>,
     nogoodnik: Option<Nogoodnik>,
 }
 
@@ -41,6 +44,10 @@ impl IntoIterator for Providers {
         }
 
         if let Some(provider) = self.tomorrow {
+            vec.push(Arc::new(provider));
+        }
+
+        if let Some(provider) = self.dwd {
             vec.push(Arc::new(provider));
         }
 
@@ -73,7 +80,7 @@ pub trait WeatherProvider: std::fmt::Debug {
 
     fn for_coordinates(
         &self,
-        cache: &Cache<String, String>,
+        cache: &RequestBody,
         request: &WeatherRequest<Coordinates>,
     ) -> anyhow::Result<Weather>;
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -12,10 +12,10 @@ use crate::providers::tomorrow::Tomorrow;
 use crate::providers::units::{Celsius, Ratio};
 use moka::sync::Cache;
 use serde::{Deserialize, Serialize};
-use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 use std::time::Duration;
 use std::vec::IntoIter;
+use units::Coordinates;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Providers {
@@ -50,29 +50,6 @@ impl IntoIterator for Providers {
 
         IntoIter::into_iter(vec.into_iter())
     }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct Coordinate(f32);
-impl Display for Coordinate {
-    // Standardize 7 digits for coordinates and that should be plenty
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:.7}", self.0)
-    }
-}
-
-impl From<f32> for Coordinate {
-    fn from(value: f32) -> Self {
-        Self(value)
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct Coordinates {
-    #[serde(alias = "lat")]
-    pub latitude: Coordinate,
-    #[serde(alias = "lon")]
-    pub longitude: Coordinate,
 }
 
 #[derive(Debug)]

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,4 +1,4 @@
-pub mod cache;
+mod cache;
 mod dwd;
 mod meteoblue;
 mod nogoodnik;
@@ -6,7 +6,6 @@ mod open_weather;
 mod tomorrow;
 pub mod units;
 
-use crate::providers::cache::RequestBody;
 use crate::providers::dwd::Dwd;
 use crate::providers::meteoblue::Meteoblue;
 use crate::providers::nogoodnik::Nogoodnik;
@@ -80,7 +79,7 @@ pub trait WeatherProvider: std::fmt::Debug {
 
     fn for_coordinates(
         &self,
-        cache: &RequestBody,
+        cache: &HttpRequestBodyCache,
         request: &WeatherRequest<Coordinates>,
     ) -> anyhow::Result<Weather>;
 
@@ -89,3 +88,5 @@ pub trait WeatherProvider: std::fmt::Debug {
         1
     }
 }
+
+pub type HttpRequestBodyCache = cache::HttpRequestBody;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -85,4 +85,7 @@ pub trait WeatherProvider: std::fmt::Debug {
     ) -> anyhow::Result<Weather>;
 
     fn refresh_interval(&self) -> Duration;
+    fn cache_cardinality(&self) -> usize {
+        1
+    }
 }

--- a/src/providers/nogoodnik.rs
+++ b/src/providers/nogoodnik.rs
@@ -1,5 +1,5 @@
-use crate::providers::cache::RequestBody;
 use crate::providers::units::Coordinates;
+use crate::providers::HttpRequestBodyCache;
 use crate::providers::{Weather, WeatherProvider, WeatherRequest};
 use anyhow::format_err;
 use rocket::serde::Serialize;
@@ -18,7 +18,7 @@ impl WeatherProvider for Nogoodnik {
 
     fn for_coordinates(
         &self,
-        _cache: &RequestBody,
+        _cache: &HttpRequestBodyCache,
         _request: &WeatherRequest<Coordinates>,
     ) -> anyhow::Result<Weather> {
         Err(format_err!("This provider is no good and always fails"))

--- a/src/providers/nogoodnik.rs
+++ b/src/providers/nogoodnik.rs
@@ -1,7 +1,7 @@
+use crate::providers::cache::RequestBody;
 use crate::providers::units::Coordinates;
 use crate::providers::{Weather, WeatherProvider, WeatherRequest};
 use anyhow::format_err;
-use moka::sync::Cache;
 use rocket::serde::Serialize;
 use serde::Deserialize;
 use std::time::Duration;
@@ -18,7 +18,7 @@ impl WeatherProvider for Nogoodnik {
 
     fn for_coordinates(
         &self,
-        _cache: &Cache<String, String>,
+        _cache: &RequestBody,
         _request: &WeatherRequest<Coordinates>,
     ) -> anyhow::Result<Weather> {
         Err(format_err!("This provider is no good and always fails"))

--- a/src/providers/nogoodnik.rs
+++ b/src/providers/nogoodnik.rs
@@ -1,4 +1,5 @@
-use crate::providers::{Coordinates, Weather, WeatherProvider, WeatherRequest};
+use crate::providers::units::Coordinates;
+use crate::providers::{Weather, WeatherProvider, WeatherRequest};
 use anyhow::format_err;
 use moka::sync::Cache;
 use rocket::serde::Serialize;

--- a/src/providers/open_weather.rs
+++ b/src/providers/open_weather.rs
@@ -1,6 +1,6 @@
-use crate::providers::cache::{reqwest_cached_body_json, Configuration, RequestBody};
+use crate::providers::cache::{reqwest_cached_body_json, Configuration};
 use crate::providers::units::{Coordinates, Kelvin, Ratio, ToCelsius};
-use crate::providers::{Weather, WeatherProvider, WeatherRequest};
+use crate::providers::{HttpRequestBodyCache, Weather, WeatherProvider, WeatherRequest};
 use reqwest::{Method, Url};
 use rocket::serde::Deserialize;
 use serde::Serialize;
@@ -37,7 +37,7 @@ impl WeatherProvider for OpenWeather {
 
     fn for_coordinates(
         &self,
-        cache: &RequestBody,
+        cache: &HttpRequestBodyCache,
         request: &WeatherRequest<Coordinates>,
     ) -> anyhow::Result<Weather> {
         let url = Url::parse_with_params(

--- a/src/providers/open_weather.rs
+++ b/src/providers/open_weather.rs
@@ -1,7 +1,6 @@
-use crate::providers::cache::{reqwest_cached_body_json, Configuration};
+use crate::providers::cache::{reqwest_cached_body_json, Configuration, RequestBody};
 use crate::providers::units::{Coordinates, Kelvin, Ratio, ToCelsius};
 use crate::providers::{Weather, WeatherProvider, WeatherRequest};
-use moka::sync::Cache;
 use reqwest::{Method, Url};
 use rocket::serde::Deserialize;
 use serde::Serialize;
@@ -38,7 +37,7 @@ impl WeatherProvider for OpenWeather {
 
     fn for_coordinates(
         &self,
-        cache: &Cache<String, String>,
+        cache: &RequestBody,
         request: &WeatherRequest<Coordinates>,
     ) -> anyhow::Result<Weather> {
         let url = Url::parse_with_params(
@@ -58,6 +57,7 @@ impl WeatherProvider for OpenWeather {
             &client,
             Method::GET,
             url,
+            None,
         )?;
 
         Ok(Weather {

--- a/src/providers/open_weather.rs
+++ b/src/providers/open_weather.rs
@@ -1,6 +1,6 @@
 use crate::providers::cache::{reqwest_cached_body_json, Configuration};
-use crate::providers::units::{Kelvin, Ratio, ToCelsius};
-use crate::providers::{Coordinates, Weather, WeatherProvider, WeatherRequest};
+use crate::providers::units::{Coordinates, Kelvin, Ratio, ToCelsius};
+use crate::providers::{Weather, WeatherProvider, WeatherRequest};
 use moka::sync::Cache;
 use reqwest::{Method, Url};
 use rocket::serde::Deserialize;

--- a/src/providers/tomorrow.rs
+++ b/src/providers/tomorrow.rs
@@ -1,7 +1,6 @@
-use crate::providers::cache::{reqwest_cached_body_json, Configuration};
+use crate::providers::cache::{reqwest_cached_body_json, Configuration, RequestBody};
 use crate::providers::units::{Celsius, Coordinates, Ratio};
 use crate::providers::{Weather, WeatherProvider, WeatherRequest};
-use moka::sync::Cache;
 use reqwest::{Method, Url};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -49,7 +48,7 @@ impl WeatherProvider for Tomorrow {
 
     fn for_coordinates(
         &self,
-        cache: &Cache<String, String>,
+        cache: &RequestBody,
         request: &WeatherRequest<Coordinates>,
     ) -> anyhow::Result<Weather> {
         let url = Url::parse_with_params(
@@ -76,6 +75,7 @@ impl WeatherProvider for Tomorrow {
             &client,
             Method::GET,
             url,
+            None,
         )?;
 
         let values = &response

--- a/src/providers/tomorrow.rs
+++ b/src/providers/tomorrow.rs
@@ -1,6 +1,6 @@
 use crate::providers::cache::{reqwest_cached_body_json, Configuration};
-use crate::providers::units::{Celsius, Ratio};
-use crate::providers::{Coordinates, Weather, WeatherProvider, WeatherRequest};
+use crate::providers::units::{Celsius, Coordinates, Ratio};
+use crate::providers::{Weather, WeatherProvider, WeatherRequest};
 use moka::sync::Cache;
 use reqwest::{Method, Url};
 use serde::{Deserialize, Serialize};

--- a/src/providers/tomorrow.rs
+++ b/src/providers/tomorrow.rs
@@ -1,6 +1,6 @@
-use crate::providers::cache::{reqwest_cached_body_json, Configuration, RequestBody};
+use crate::providers::cache::{reqwest_cached_body_json, Configuration};
 use crate::providers::units::{Celsius, Coordinates, Ratio};
-use crate::providers::{Weather, WeatherProvider, WeatherRequest};
+use crate::providers::{HttpRequestBodyCache, Weather, WeatherProvider, WeatherRequest};
 use reqwest::{Method, Url};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -48,7 +48,7 @@ impl WeatherProvider for Tomorrow {
 
     fn for_coordinates(
         &self,
-        cache: &RequestBody,
+        cache: &HttpRequestBodyCache,
         request: &WeatherRequest<Coordinates>,
     ) -> anyhow::Result<Weather> {
         let url = Url::parse_with_params(

--- a/src/providers/units.rs
+++ b/src/providers/units.rs
@@ -1,5 +1,6 @@
+use rocket::serde::Serialize;
 use serde::Deserialize;
-use std::fmt::Debug;
+use std::fmt::{Debug, Display, Formatter};
 
 #[derive(Deserialize, Debug, Copy, Clone)]
 pub struct Kelvin(f32);
@@ -71,4 +72,28 @@ impl Ratio {
             Self::Percentage(v) => f64::from(*v) / 100.0,
         }
     }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Coordinate(f32);
+
+impl Display for Coordinate {
+    // Standardize 7 digits for coordinates and that should be plenty
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:.7}", self.0)
+    }
+}
+
+impl From<f32> for Coordinate {
+    fn from(value: f32) -> Self {
+        Self(value)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Coordinates {
+    #[serde(alias = "lat")]
+    pub latitude: Coordinate,
+    #[serde(alias = "lon")]
+    pub longitude: Coordinate,
 }

--- a/src/providers/units.rs
+++ b/src/providers/units.rs
@@ -62,6 +62,7 @@ impl ToCelsius for Fahrenheit {
 #[serde(untagged)]
 pub enum Ratio {
     Percentage(u16),
+    PercentageDecimal(f64),
     Ratio(f64),
 }
 
@@ -70,12 +71,19 @@ impl Ratio {
         match self {
             Self::Ratio(v) => *v,
             Self::Percentage(v) => f64::from(*v) / 100.0,
+            Self::PercentageDecimal(v) => v / 100.0,
         }
     }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct Coordinate(f32);
+pub struct Coordinate(f64);
+
+impl PartialEq for Coordinate {
+    fn eq(&self, other: &Self) -> bool {
+        (self.0 - other.0).abs() < 0.000_000_1
+    }
+}
 
 impl Display for Coordinate {
     // Standardize 7 digits for coordinates and that should be plenty
@@ -84,9 +92,15 @@ impl Display for Coordinate {
     }
 }
 
-impl From<f32> for Coordinate {
-    fn from(value: f32) -> Self {
+impl From<f64> for Coordinate {
+    fn from(value: f64) -> Self {
         Self(value)
+    }
+}
+
+impl From<Coordinate> for f64 {
+    fn from(val: Coordinate) -> Self {
+        val.0
     }
 }
 

--- a/src/providers/units.rs
+++ b/src/providers/units.rs
@@ -18,7 +18,7 @@ impl ToCelsius for Kelvin {
     }
 }
 
-#[derive(Deserialize, Debug, Copy, Clone)]
+#[derive(Deserialize, Debug, Copy, Clone, PartialEq)]
 pub struct Celsius(f32);
 
 impl From<f32> for Celsius {
@@ -58,7 +58,7 @@ impl ToCelsius for Fahrenheit {
     }
 }
 
-#[derive(Deserialize, Debug, Copy, Clone)]
+#[derive(Deserialize, Debug, Copy, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum Ratio {
     Percentage(u16),

--- a/weathermen.toml.dist
+++ b/weathermen.toml.dist
@@ -42,6 +42,11 @@ longitude = 14.435965
 # refresh_interval = "10min"
 
 
+# [provider.deutscher_wetterdienst]
+#
+# A provider using Deutscher Wetterdienst Open Data, the state run weather service in Germany
+
+
 # [provider.nogoodnik]
 #
 # A provider that always fails (for robustness testing)


### PR DESCRIPTION
German state run weather service provides [open data](https://www.dwd.de/DE/leistungen/opendata/opendata.html) from their weather stations around Germany. Format is a bit [whacky](https://opendata.dwd.de/) in so far that we need to download a textfile first to find the closest weather station and then extract the latest measurement file from a zip, but we’ll manage.