### PR TITLE
Include weathermen.toml.dist in build archive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,9 @@ jobs:
         run: echo archive_name=prometheus-weathermen-${{ steps.metadata.outputs.version }}-${{ matrix.desc}}.tar.zz >> $GITHUB_OUTPUT
 
       - name: Create archive
-        run: tar -C target/${{ matrix.target }}/${{ matrix.profile }} -Jcvf ${{ steps.archive.outputs.archive_name }} prometheus-weathermen
+        run: |
+          cp weathermen.toml.dist target/${{ matrix.target }}/${{ matrix.profile }}
+          tar -C target/${{ matrix.target }}/${{ matrix.profile }} -Jcvf ${{ steps.archive.outputs.archive_name }} prometheus-weathermen weathermen.toml.dist
 
       - name: Upload ${{ matrix.profile }} binary
         uses: actions/upload-artifact@v3.1.2


### PR DESCRIPTION
Include dist config file in build archive to simplify local installation.