### PR TITLE
Refactor providers to have the HTTP client injected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-weathermen"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert-str",

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ use figment::{
     Figment,
 };
 use log::{debug, info, warn, Level};
+use reqwest::blocking::Client;
 use rocket::config::Ident;
 use rocket::figment::providers::Serialized;
 use rocket::serde::Serialize;
@@ -103,6 +104,7 @@ pub type ProviderTasks = Vec<Task>;
 pub struct Task {
     pub provider: Arc<dyn WeatherProvider + Send + Sync>,
     pub request: WeatherRequest<Coordinates>,
+    pub client: Client,
     pub cache: HttpRequestBodyCache,
 }
 
@@ -136,6 +138,7 @@ pub fn get_provider_tasks(config: Config) -> anyhow::Result<ProviderTasks> {
                     name: location.name.unwrap_or(name),
                     query: location.coordinates,
                 },
+                client: Client::new(),
                 cache: cache.clone(),
             });
         }

--- a/src/http.rs
+++ b/src/http.rs
@@ -50,7 +50,8 @@ async fn serve_metrics(unscheduled_tasks: &State<ProviderTasks>) -> (Status, Str
                 task.provider.id(),
                 task.request.query,
             );
-            task.provider.for_coordinates(&task.cache, &task.request)
+            task.provider
+                .for_coordinates(&task.client, &task.cache, &task.request)
         }));
     }
 

--- a/src/providers/cache.rs
+++ b/src/providers/cache.rs
@@ -25,7 +25,7 @@ pub fn reqwest_cached_body_json<T: DeserializeOwned + std::fmt::Debug>(
     cache: &HttpRequestBodyCache,
     client: &Client,
     method: Method,
-    url: Url,
+    url: &Url,
     charset: Option<&str>,
 ) -> anyhow::Result<T> {
     let body = reqwest_cached_body(source, cache, client, method, url, charset)?;
@@ -44,7 +44,7 @@ pub fn reqwest_cached_body(
     cache: &HttpRequestBodyCache,
     client: &Client,
     method: Method,
-    url: Url,
+    url: &Url,
     charset: Option<&str>,
 ) -> anyhow::Result<String> {
     let key = (method.clone(), url.clone());
@@ -66,7 +66,7 @@ pub fn reqwest_cached_body(
     debug!("No cache item found for \"{method:#} {url:#}\". Requesting");
 
     let body = client
-        .request(method, url)
+        .request(method, url.clone())
         .send()?
         .text_with_charset(charset.unwrap_or("utf-8"))?;
     cache.insert(key, body.clone());

--- a/src/providers/deutscher_wetterdienst.rs
+++ b/src/providers/deutscher_wetterdienst.rs
@@ -219,9 +219,9 @@ impl WeatherProvider for DeutscherWetterdienst {
         let station_csv = reqwest_cached_body(
             SOURCE_URI,
             cache,
-            &client,
+            client,
             Method::GET,
-            Url::parse(STATION_LIST_URL)?,
+            &Url::parse(STATION_LIST_URL)?,
             Some("iso-8859-15"),
         )?;
 
@@ -229,7 +229,7 @@ impl WeatherProvider for DeutscherWetterdienst {
         let closest_station = find_closest_weather_station(&request.query, &stations)?;
         trace!("Found closest weather station {:?}", closest_station);
         let measurement_csv =
-            reqwest_cached_measurement_csv(cache, &client, &closest_station.station_id)?;
+            reqwest_cached_measurement_csv(cache, client, &closest_station.station_id)?;
         let measurements = parse_measurement_data_csv(&measurement_csv);
         let latest_measurement = measurements.last().expect("Taking last measurement info");
 

--- a/src/providers/deutscher_wetterdienst.rs
+++ b/src/providers/deutscher_wetterdienst.rs
@@ -212,11 +212,10 @@ impl WeatherProvider for DeutscherWetterdienst {
 
     fn for_coordinates(
         &self,
+        client: &Client,
         cache: &HttpRequestBodyCache,
         request: &WeatherRequest<Coordinates>,
     ) -> anyhow::Result<Weather> {
-        let client = Client::new();
-
         let station_csv = reqwest_cached_body(
             SOURCE_URI,
             cache,

--- a/src/providers/meteoblue.rs
+++ b/src/providers/meteoblue.rs
@@ -3,6 +3,7 @@ use crate::providers::units::{Celsius, Coordinates};
 use crate::providers::{HttpRequestBodyCache, Weather, WeatherProvider, WeatherRequest};
 use anyhow::Context;
 use hmac::{Hmac, Mac};
+use reqwest::blocking::Client;
 use reqwest::{Method, Url};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
@@ -45,6 +46,7 @@ impl WeatherProvider for Meteoblue {
 
     fn for_coordinates(
         &self,
+        client: &Client,
         cache: &HttpRequestBodyCache,
         request: &WeatherRequest<Coordinates>,
     ) -> anyhow::Result<Weather> {
@@ -73,7 +75,6 @@ impl WeatherProvider for Meteoblue {
 
         let signed_url = Url::parse_with_params(url.as_str(), &[("sig", sig)])?;
 
-        let client = reqwest::blocking::Client::new();
         let response: MeteoblueResponse = reqwest_cached_body_json::<MeteoblueResponse>(
             SOURCE_URI,
             cache,

--- a/src/providers/meteoblue.rs
+++ b/src/providers/meteoblue.rs
@@ -78,9 +78,9 @@ impl WeatherProvider for Meteoblue {
         let response: MeteoblueResponse = reqwest_cached_body_json::<MeteoblueResponse>(
             SOURCE_URI,
             cache,
-            &client,
+            client,
             Method::GET,
-            signed_url,
+            &signed_url,
             None,
         )?;
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -12,6 +12,7 @@ use crate::providers::nogoodnik::Nogoodnik;
 use crate::providers::open_weather::OpenWeather;
 use crate::providers::tomorrow::Tomorrow;
 use crate::providers::units::{Celsius, Ratio};
+use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
@@ -79,6 +80,7 @@ pub trait WeatherProvider: std::fmt::Debug {
 
     fn for_coordinates(
         &self,
+        client: &Client,
         cache: &HttpRequestBodyCache,
         request: &WeatherRequest<Coordinates>,
     ) -> anyhow::Result<Weather>;

--- a/src/providers/nogoodnik.rs
+++ b/src/providers/nogoodnik.rs
@@ -2,6 +2,7 @@ use crate::providers::units::Coordinates;
 use crate::providers::HttpRequestBodyCache;
 use crate::providers::{Weather, WeatherProvider, WeatherRequest};
 use anyhow::format_err;
+use reqwest::blocking::Client;
 use rocket::serde::Serialize;
 use serde::Deserialize;
 use std::time::Duration;
@@ -18,6 +19,7 @@ impl WeatherProvider for Nogoodnik {
 
     fn for_coordinates(
         &self,
+        _client: &Client,
         _cache: &HttpRequestBodyCache,
         _request: &WeatherRequest<Coordinates>,
     ) -> anyhow::Result<Weather> {

--- a/src/providers/open_weather.rs
+++ b/src/providers/open_weather.rs
@@ -54,9 +54,9 @@ impl WeatherProvider for OpenWeather {
         let response = reqwest_cached_body_json::<OpenWeatherResponse>(
             SOURCE_URI,
             cache,
-            &client,
+            client,
             Method::GET,
-            url,
+            &url,
             None,
         )?;
 

--- a/src/providers/open_weather.rs
+++ b/src/providers/open_weather.rs
@@ -1,6 +1,7 @@
 use crate::providers::cache::{reqwest_cached_body_json, Configuration};
 use crate::providers::units::{Coordinates, Kelvin, Ratio, ToCelsius};
 use crate::providers::{HttpRequestBodyCache, Weather, WeatherProvider, WeatherRequest};
+use reqwest::blocking::Client;
 use reqwest::{Method, Url};
 use rocket::serde::Deserialize;
 use serde::Serialize;
@@ -37,6 +38,7 @@ impl WeatherProvider for OpenWeather {
 
     fn for_coordinates(
         &self,
+        client: &Client,
         cache: &HttpRequestBodyCache,
         request: &WeatherRequest<Coordinates>,
     ) -> anyhow::Result<Weather> {
@@ -48,8 +50,6 @@ impl WeatherProvider for OpenWeather {
                 ("appid", self.api_key.to_string()),
             ],
         )?;
-
-        let client = reqwest::blocking::Client::new();
 
         let response = reqwest_cached_body_json::<OpenWeatherResponse>(
             SOURCE_URI,

--- a/src/providers/tomorrow.rs
+++ b/src/providers/tomorrow.rs
@@ -1,6 +1,7 @@
 use crate::providers::cache::{reqwest_cached_body_json, Configuration};
 use crate::providers::units::{Celsius, Coordinates, Ratio};
 use crate::providers::{HttpRequestBodyCache, Weather, WeatherProvider, WeatherRequest};
+use reqwest::blocking::Client;
 use reqwest::{Method, Url};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -48,6 +49,7 @@ impl WeatherProvider for Tomorrow {
 
     fn for_coordinates(
         &self,
+        client: &Client,
         cache: &HttpRequestBodyCache,
         request: &WeatherRequest<Coordinates>,
     ) -> anyhow::Result<Weather> {
@@ -66,8 +68,6 @@ impl WeatherProvider for Tomorrow {
                 ("endTime", "nowPlus1m".into()),
             ],
         )?;
-
-        let client = reqwest::blocking::Client::new();
 
         let response = reqwest_cached_body_json::<TomorrowResponse>(
             SOURCE_URI,

--- a/src/providers/tomorrow.rs
+++ b/src/providers/tomorrow.rs
@@ -72,9 +72,9 @@ impl WeatherProvider for Tomorrow {
         let response = reqwest_cached_body_json::<TomorrowResponse>(
             SOURCE_URI,
             cache,
-            &client,
+            client,
             Method::GET,
-            url,
+            &url,
             None,
         )?;
 


### PR DESCRIPTION
Instead of adapters creating their own HTTP client, create the clients when assembling tasks from the config.