### PR TITLE
Linux specific distribution archive with systemd service definition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,11 +126,15 @@ jobs:
           SUFFIX: ${{ matrix.desc }}
           TARGET: ${{ matrix.target }}
 
+      - name: Find archive
+        run: echo archive=`ls prometheus-weathermen-*.tar.zz` >> $GITHUB_OUTPUT
+        id: list-archive
+
       - name: Upload ${{ matrix.profile }} binary
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: distribution-${{ matrix.desc }}-${{ matrix.target }}-${{ matrix.profile }}
-          path: prometheus-weathermen-*.tar.zz
+          name: ${{ steps.list-archive.outputs.archive }}
+          path: ${{ steps.list-archive.outputs.archive }}
           if-no-files-found: error
 
   release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,20 +66,20 @@ jobs:
       matrix:
         include:
           - { desc: arm-mac,                    target: aarch64-apple-darwin,               host: macos-12,         profile: release,     toolchain: stable }
-          #- { desc: arm-mac-dbg,                target: aarch64-apple-darwin,               host: macos-12,         profile: debug,       toolchain: stable }
-          #- { desc: intel-mac,                  target: x86_64-apple-darwin,                host: macos-12,         profile: release,     toolchain: stable }
-          #- { desc: intel-mac-dbg,              target: x86_64-apple-darwin,                host: macos-12,         profile: debug,       toolchain: stable }
-          #- { desc: arm-linux,                  target: armv7-unknown-linux-gnueabihf,      host: ubuntu-22.04,     profile: release,     toolchain: stable }
-          #- { desc: arm-linux-dbg,              target: armv7-unknown-linux-gnueabihf,      host: ubuntu-22.04,     profile: debug,       toolchain: stable }
-          #- { desc: arm-linux-static,           target: armv7-unknown-linux-musleabihf,     host: ubuntu-22.04,     profile: release,     toolchain: stable }
-          #- { desc: arm-linux-static-dbg,       target: armv7-unknown-linux-musleabihf,     host: ubuntu-22.04,     profile: debug,       toolchain: stable }
-          #- { desc: arm64-linux,                target: aarch64-unknown-linux-gnu,          host: ubuntu-22.04,     profile: release,     toolchain: stable }
-          #- { desc: arm64-linux-dbg,            target: aarch64-unknown-linux-gnu,          host: ubuntu-22.04,     profile: debug,       toolchain: stable }
-          #- { desc: arm64-linux-static,         target: aarch64-unknown-linux-musl,         host: ubuntu-22.04,     profile: release,     toolchain: stable }
-          #- { desc: arm64-linux-static-dbg,     target: aarch64-unknown-linux-musl,         host: ubuntu-22.04,     profile: debug,       toolchain: stable }
-          #- { desc: x86_64-linux,               target: x86_64-unknown-linux-gnu,           host: ubuntu-22.04,     profile: release,     toolchain: stable }
-          #- { desc: x86_64-linux-dbg,           target: x86_64-unknown-linux-gnu,           host: ubuntu-22.04,     profile: debug,       toolchain: stable }
-          #- { desc: x86_64-linux-static,        target: x86_64-unknown-linux-musl,          host: ubuntu-22.04,     profile: release,     toolchain: stable }
+          - { desc: arm-mac-dbg,                target: aarch64-apple-darwin,               host: macos-12,         profile: debug,       toolchain: stable }
+          - { desc: intel-mac,                  target: x86_64-apple-darwin,                host: macos-12,         profile: release,     toolchain: stable }
+          - { desc: intel-mac-dbg,              target: x86_64-apple-darwin,                host: macos-12,         profile: debug,       toolchain: stable }
+          - { desc: arm-linux,                  target: armv7-unknown-linux-gnueabihf,      host: ubuntu-22.04,     profile: release,     toolchain: stable }
+          - { desc: arm-linux-dbg,              target: armv7-unknown-linux-gnueabihf,      host: ubuntu-22.04,     profile: debug,       toolchain: stable }
+          - { desc: arm-linux-static,           target: armv7-unknown-linux-musleabihf,     host: ubuntu-22.04,     profile: release,     toolchain: stable }
+          - { desc: arm-linux-static-dbg,       target: armv7-unknown-linux-musleabihf,     host: ubuntu-22.04,     profile: debug,       toolchain: stable }
+          - { desc: arm64-linux,                target: aarch64-unknown-linux-gnu,          host: ubuntu-22.04,     profile: release,     toolchain: stable }
+          - { desc: arm64-linux-dbg,            target: aarch64-unknown-linux-gnu,          host: ubuntu-22.04,     profile: debug,       toolchain: stable }
+          - { desc: arm64-linux-static,         target: aarch64-unknown-linux-musl,         host: ubuntu-22.04,     profile: release,     toolchain: stable }
+          - { desc: arm64-linux-static-dbg,     target: aarch64-unknown-linux-musl,         host: ubuntu-22.04,     profile: debug,       toolchain: stable }
+          - { desc: x86_64-linux,               target: x86_64-unknown-linux-gnu,           host: ubuntu-22.04,     profile: release,     toolchain: stable }
+          - { desc: x86_64-linux-dbg,           target: x86_64-unknown-linux-gnu,           host: ubuntu-22.04,     profile: debug,       toolchain: stable }
+          - { desc: x86_64-linux-static,        target: x86_64-unknown-linux-musl,          host: ubuntu-22.04,     profile: release,     toolchain: stable }
           - { desc: x86_64-linux-static-dbg,    target: x86_64-unknown-linux-musl,          host: ubuntu-22.04,     profile: debug,       toolchain: stable }
     runs-on: ${{ matrix.host }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,6 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
           override: true
-          components: rustfmt, clippy
 
       - name: Set up cargo cache
         uses: actions/cache@v3.2.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,20 +68,20 @@ jobs:
       matrix:
         include:
           - { desc: arm-mac,                    target: aarch64-apple-darwin,               host: macos-12,         profile: release,     toolchain: stable }
-          - { desc: arm-mac-dbg,                target: aarch64-apple-darwin,               host: macos-12,         profile: debug,       toolchain: stable }
-          - { desc: intel-mac,                  target: x86_64-apple-darwin,                host: macos-12,         profile: release,     toolchain: stable }
-          - { desc: intel-mac-dbg,              target: x86_64-apple-darwin,                host: macos-12,         profile: debug,       toolchain: stable }
-          - { desc: arm-linux,                  target: armv7-unknown-linux-gnueabihf,      host: ubuntu-22.04,     profile: release,     toolchain: stable }
-          - { desc: arm-linux-dbg,              target: armv7-unknown-linux-gnueabihf,      host: ubuntu-22.04,     profile: debug,       toolchain: stable }
-          - { desc: arm-linux-static,           target: armv7-unknown-linux-musleabihf,     host: ubuntu-22.04,     profile: release,     toolchain: stable }
-          - { desc: arm-linux-static-dbg,       target: armv7-unknown-linux-musleabihf,     host: ubuntu-22.04,     profile: debug,       toolchain: stable }
-          - { desc: arm64-linux,                target: aarch64-unknown-linux-gnu,          host: ubuntu-22.04,     profile: release,     toolchain: stable }
-          - { desc: arm64-linux-dbg,            target: aarch64-unknown-linux-gnu,          host: ubuntu-22.04,     profile: debug,       toolchain: stable }
-          - { desc: arm64-linux-static,         target: aarch64-unknown-linux-musl,         host: ubuntu-22.04,     profile: release,     toolchain: stable }
-          - { desc: arm64-linux-static-dbg,     target: aarch64-unknown-linux-musl,         host: ubuntu-22.04,     profile: debug,       toolchain: stable }
-          - { desc: x86_64-linux,               target: x86_64-unknown-linux-gnu,           host: ubuntu-22.04,     profile: release,     toolchain: stable }
-          - { desc: x86_64-linux-dbg,           target: x86_64-unknown-linux-gnu,           host: ubuntu-22.04,     profile: debug,       toolchain: stable }
-          - { desc: x86_64-linux-static,        target: x86_64-unknown-linux-musl,          host: ubuntu-22.04,     profile: release,     toolchain: stable }
+          #- { desc: arm-mac-dbg,                target: aarch64-apple-darwin,               host: macos-12,         profile: debug,       toolchain: stable }
+          #- { desc: intel-mac,                  target: x86_64-apple-darwin,                host: macos-12,         profile: release,     toolchain: stable }
+          #- { desc: intel-mac-dbg,              target: x86_64-apple-darwin,                host: macos-12,         profile: debug,       toolchain: stable }
+          #- { desc: arm-linux,                  target: armv7-unknown-linux-gnueabihf,      host: ubuntu-22.04,     profile: release,     toolchain: stable }
+          #- { desc: arm-linux-dbg,              target: armv7-unknown-linux-gnueabihf,      host: ubuntu-22.04,     profile: debug,       toolchain: stable }
+          #- { desc: arm-linux-static,           target: armv7-unknown-linux-musleabihf,     host: ubuntu-22.04,     profile: release,     toolchain: stable }
+          #- { desc: arm-linux-static-dbg,       target: armv7-unknown-linux-musleabihf,     host: ubuntu-22.04,     profile: debug,       toolchain: stable }
+          #- { desc: arm64-linux,                target: aarch64-unknown-linux-gnu,          host: ubuntu-22.04,     profile: release,     toolchain: stable }
+          #- { desc: arm64-linux-dbg,            target: aarch64-unknown-linux-gnu,          host: ubuntu-22.04,     profile: debug,       toolchain: stable }
+          #- { desc: arm64-linux-static,         target: aarch64-unknown-linux-musl,         host: ubuntu-22.04,     profile: release,     toolchain: stable }
+          #- { desc: arm64-linux-static-dbg,     target: aarch64-unknown-linux-musl,         host: ubuntu-22.04,     profile: debug,       toolchain: stable }
+          #- { desc: x86_64-linux,               target: x86_64-unknown-linux-gnu,           host: ubuntu-22.04,     profile: release,     toolchain: stable }
+          #- { desc: x86_64-linux-dbg,           target: x86_64-unknown-linux-gnu,           host: ubuntu-22.04,     profile: debug,       toolchain: stable }
+          #- { desc: x86_64-linux-static,        target: x86_64-unknown-linux-musl,          host: ubuntu-22.04,     profile: release,     toolchain: stable }
           - { desc: x86_64-linux-static-dbg,    target: x86_64-unknown-linux-musl,          host: ubuntu-22.04,     profile: debug,       toolchain: stable }
     runs-on: ${{ matrix.host }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,7 @@ jobs:
           profile: minimal
           target: ${{ matrix.target }}
           override: true
+          components: cross
 
       - name: Set up cargo cache
         uses: actions/cache@v3.2.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,7 @@ jobs:
           profile: minimal
           target: ${{ matrix.target }}
           override: true
+          components: rustfmt, clippy
 
       - name: Set up cargo cache
         uses: actions/cache@v3.2.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,6 @@ jobs:
           profile: minimal
           target: ${{ matrix.target }}
           override: true
-          components: cross
 
       - name: Set up cargo cache
         uses: actions/cache@v3.2.3
@@ -113,6 +112,12 @@ jobs:
             cargo-${{ runner.os }}-${{ matrix.toolchain }}-${{ matrix.target }}-${{ matrix.profile }}-${{ hashFiles('**/Cargo.lock') }}
             cargo-${{ runner.os }}-${{ matrix.toolchain }}-${{ matrix.target }}-${{ matrix.profile }}
             cargo-${{ runner.os }}-${{ matrix.toolchain }}-${{ matrix.target }}
+
+      - name: Install cross
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          use-cross: true
+          command: help
 
       - name: Build ${{ matrix.profile }} archive
         run: make dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
+          components: rustfmt, clippy
 
       - name: Set up cargo cache
         uses: actions/cache@v3.2.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
-          override: true
 
       - name: Set up cargo cache
         uses: actions/cache@v3.2.3
@@ -93,7 +92,6 @@ jobs:
           toolchain: stable
           profile: minimal
           target: ${{ matrix.target }}
-          override: true
           components: rustfmt, clippy
 
       - name: Set up cargo cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,35 +113,20 @@ jobs:
             cargo-${{ runner.os }}-${{ matrix.toolchain }}-${{ matrix.target }}-${{ matrix.profile }}
             cargo-${{ runner.os }}-${{ matrix.toolchain }}-${{ matrix.target }}
 
-      - name: Build ${{ matrix.profile }} binary
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          use-cross: true
-          command: build
-          args: ${{ matrix.profile == 'release' && '--release' || '' }} --target=${{ matrix.target }}
-
-      - name: Set GIT short sha
-        id: git
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
-      - name: Get metadata
-        id: metadata
-        run: echo version=`cargo metadata --format-version=1 --no-deps | jq -r .packages[0].version`${{ !startsWith(github.ref, 'refs/tags/') && format('-{0}', steps.git.outputs.sha_short) || '' }} >> $GITHUB_OUTPUT
-
-      - name: Set archive name
-        id: archive
-        run: echo archive_name=prometheus-weathermen-${{ steps.metadata.outputs.version }}-${{ matrix.desc}}.tar.zz >> $GITHUB_OUTPUT
-
-      - name: Create archive
-        run: |
-          cp weathermen.toml.dist target/${{ matrix.target }}/${{ matrix.profile }}
-          tar -C target/${{ matrix.target }}/${{ matrix.profile }} -Jcvf ${{ steps.archive.outputs.archive_name }} prometheus-weathermen weathermen.toml.dist
+      - name: Build ${{ matrix.profile }} archive
+        run: make dist
+        env:
+          CARGO: cross
+          DEBUG: ${{ matrix.profile == 'debug' && 1 || 0 }}
+          RELEASE: ${{ startsWith(github.ref, 'refs/tags/') && 1 || 0 }}
+          SUFFIX: ${{ matrix.desc }}
+          TARGET: ${{ matrix.target }}
 
       - name: Upload ${{ matrix.profile }} binary
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: ${{ steps.archive.outputs.archive_name }}
-          path: ${{ steps.archive.outputs.archive_name }}
+          name: distribution-${{ matrix.desc }}-${{ matrix.target }}-${{ matrix.profile }}
+          path: prometheus-weathermen-*.tar.zz
           if-no-files-found: error
 
   release:

--- a/Cross.toml
+++ b/Cross.toml
@@ -11,3 +11,14 @@ image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge"
 
 [target.armv7-unknown-linux-gnueabihf]
 image = "ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:edge"
+
+
+# Use edge image for musl targets as well to get the newest toolchain
+[target.x86_64-unknown-linux-musl]
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-musl:edge"
+
+[target.aarch64-unknown-linux-musl]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl:edge"
+
+[target.armv7-unknown-linux-musleabihf]
+image = "ghcr.io/cross-rs/armv7-unknown-linux-musleabihf:edge"

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,11 @@ DEBUG ?= 1
 TARGET ?=
 
 ifneq ($(DEBUG), 0)
-  BUILD_ARGS :=
+	BUILD_ARGS :=
+	TARGET_DIR = target/$(TARGET)/debug/
 else
-  BUILD_ARGS := $(BUILD_ARGS) --release
+	BUILD_ARGS := $(BUILD_ARGS) --release
+	TARGET_DIR = target/$(TARGET)/release/
 endif
 
 ifdef TARGET
@@ -20,10 +22,8 @@ CURRENT_REVISION = $(shell git rev-parse --short HEAD)
 
 ifneq ($(RELEASE), 0)
 	VERSION = $(CURRENT_VERSION)
-	TARGET_DIR = target/$(TARGET)/debug/
 else
 	VERSION = $(CURRENT_VERSION)-$(CURRENT_REVISION)
-	TARGET_DIR = target/$(TARGET)/release/
 endif
 
 DIST_DIR = target/dist

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ PACKAGE_NAME_AND_VERSION = $(PACKAGE_NAME)-$(VERSION)-$(SUFFIX)
 ARCHIVE_DIR = $(DIST_DIR)/$(PACKAGE_NAME_AND_VERSION)
 ARCHIVE_NAME = $(PACKAGE_NAME_AND_VERSION).tar.zz
 
+.DEFAULT_GOAL = help
+.PHONY: dist build check-dist help
+
 dist: check-dist build
 	rm -rf $(ARCHIVE_DIR)
 	mkdir -p $(ARCHIVE_DIR)
@@ -57,7 +60,7 @@ ifndef SUFFIX
 	_ := $(error SUFFIX must be defined)
 endif
 
-all: build
-
 help:
-	@echo "usage: make [DEBUG=1] [RELEASE=0] [TARGET=] [SUFFIX=]"
+	@echo "Targets:"
+	@echo "Build dev target on the current machine: make build"
+	@echo "Build distribution package:              make dist [DEBUG=1] [RELEASE=0] [TARGET=] [SUFFIX=]"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,63 @@
+DEBUG ?= 1
+TARGET ?=
+
+ifneq ($(DEBUG), 0)
+  BUILD_ARGS :=
+else
+  BUILD_ARGS := $(BUILD_ARGS) --release
+endif
+
+ifdef TARGET
+  BUILD_ARGS := $(BUILD_ARGS) --target=$(TARGET)
+endif
+
+CARGO = cargo
+
+PACKAGE_METADATA = $(shell cargo metadata --format-version=1 --no-deps)
+PACKAGE_NAME = $(shell echo '$(PACKAGE_METADATA)' | jq -r .packages[0].name)
+CURRENT_VERSION = $(shell echo '$(PACKAGE_METADATA)' | jq -r .packages[0].version)
+CURRENT_REVISION = $(shell git rev-parse --short HEAD)
+
+ifneq ($(RELEASE), 0)
+	VERSION = $(CURRENT_VERSION)
+	TARGET_DIR = target/$(TARGET)/debug/
+else
+	VERSION = $(CURRENT_VERSION)-$(CURRENT_REVISION)
+	TARGET_DIR = target/$(TARGET)/release/
+endif
+
+DIST_DIR = target/dist
+PACKAGE_NAME_AND_VERSION = $(PACKAGE_NAME)-$(VERSION)-$(SUFFIX)
+ARCHIVE_DIR = $(DIST_DIR)/$(PACKAGE_NAME_AND_VERSION)
+ARCHIVE_NAME = $(PACKAGE_NAME_AND_VERSION).tar.zz
+
+dist: check-dist build
+	rm -rf $(ARCHIVE_DIR)
+	mkdir -p $(ARCHIVE_DIR)
+ifneq (, $(findstring linux, $(TARGET)))
+	$(info Building distribution with Linux layout)
+	mkdir -p $(ARCHIVE_DIR)/etc/$(PACKAGE_NAME) \
+		$(ARCHIVE_DIR)/usr/local/bin \
+		$(ARCHIVE_DIR)/etc/systemd/system
+	cp $(TARGET_DIR)/$(PACKAGE_NAME) $(ARCHIVE_DIR)/usr/local/bin/
+	cp $(PACKAGE_NAME).service $(ARCHIVE_DIR)/etc/systemd/system/
+	cp weathermen.toml.dist $(ARCHIVE_DIR)/etc/$(PACKAGE_NAME)/
+else
+	$(info Building distribution with basic layout)
+	cp $(TARGET_DIR)/$(PACKAGE_NAME) $(ARCHIVE_DIR)/
+	cp weathermen.toml.dist $(ARCHIVE_DIR)
+endif
+	tar -C $(DIST_DIR) -Jcvf $(ARCHIVE_NAME) $(PACKAGE_NAME_AND_VERSION)
+
+build:
+	$(CARGO) build $(BUILD_ARGS)
+
+check-dist:
+ifndef SUFFIX
+	_ := $(error SUFFIX must be defined)
+endif
+
+all: build
+
+help:
+	@echo "usage: make [DEBUG=1] [RELEASE=0] [TARGET=] [SUFFIX=]"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ifdef TARGET
   BUILD_ARGS := $(BUILD_ARGS) --target=$(TARGET)
 endif
 
-CARGO = cargo
+CARGO ?= cargo
 
 PACKAGE_METADATA = $(shell cargo metadata --format-version=1 --no-deps)
 PACKAGE_NAME = $(shell echo '$(PACKAGE_METADATA)' | jq -r .packages[0].name)

--- a/prometheus-weathermen.service
+++ b/prometheus-weathermen.service
@@ -1,0 +1,44 @@
+[Unit]
+Description=Prometheus weathermen service
+After=multi-user.target
+
+[Service]
+ExecStart=/usr/local/bin/prometheus-weathermen -vvv
+Restart=on-failure
+# Let systemd dynamically create a non-privileged user
+# You might need to change that to a static user if e.g. you need ACL based read permissions for TLS certificates
+DynamicUser=yes
+ProtectSystem=strict
+ReadWritePaths=/tmp
+ProtectHome=read-only
+NoNewPrivileges=yes
+PrivateDevices=yes
+PrivateMounts=yes
+PrivateTmp=yes
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectKernelLogs=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+MemoryDenyWriteExecute=yes
+LockPersonality=yes
+CapabilityBoundingSet=
+AmbientCapabilities=
+TemporaryFileSystem=/:ro
+# /usr/lib is bound here for dynamic libraries. For more exotic configurations, you might need to adjust the path
+# You can also leave it out for statically linked binaries
+BindReadOnlyPaths=/etc/prometheus-weathermen/weathermen.toml /usr/lib
+ProtectClock=true
+ProtectHome=true
+ProtectHostname=true
+RemoveIPC=true
+ProtectProc=invisible
+UMask=0777
+RestrictRealtime=yes
+SystemCallArchitectures=native
+SystemCallFilter=~@swap @resources @reboot @raw-io @privileged @obsolete @mount @module @debug @cpu-emulation @clock
+[Install]
+WantedBy=multi-user.target

--- a/src/providers/meteoblue.rs
+++ b/src/providers/meteoblue.rs
@@ -1,7 +1,6 @@
 use crate::providers::cache::{reqwest_cached_body_json, Configuration};
 use crate::providers::units::{Celsius, Coordinates};
 use crate::providers::{HttpRequestBodyCache, Weather, WeatherProvider, WeatherRequest};
-use anyhow::Context;
 use hmac::{Hmac, Mac};
 use reqwest::blocking::Client;
 use reqwest::{Method, Url};


### PR DESCRIPTION
Change Linux distribution archives:
 * Binary in /usr/local/bin
 * Example config in /etc/prometheus-weathermen
 * Hardened systemd service definition in /etc/systemd/system
 * Use cross’ edge images for static (musl) builds as well


Addresses #26 and #24 