### PR TITLE
Refactor expect

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -147,13 +147,13 @@ pub fn maybe_authenticate(
         (Some(credentials_store), Some(credentials_presented)) => {
             authenticate(credentials_store, credentials_presented)
         }
+        (Some(_), None) => {
+            trace!("No credentials presented. Unauthorized");
+            Err(Denied::Unauthorized)
+        }
         (None, _) => {
             trace!("No credentials store configured, skipping authentication");
             Ok(Granted::NotRequired)
-        }
-        (_, None) => {
-            trace!("No credentials presented. Unauthorized");
-            Err(Denied::Unauthorized)
         }
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -148,7 +148,7 @@ pub fn maybe_authenticate(
             authenticate(credentials_store, credentials_presented)
         }
         (None, _) => {
-            trace!("No credentials store configured, authentication required");
+            trace!("No credentials store configured, skipping authentication");
             Ok(Granted::NotRequired)
         }
         (_, None) => {


### PR DESCRIPTION
Handle error cases in unrealistic but still possible scenarios in a better way than delegating to `std::result.expect` which might panic