### PR TITLE
Sort output in test to make test deterministic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "prometheus-weathermen"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert-str",

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -79,7 +79,7 @@ mod tests {
     use assert_str::assert_str_eq;
     use std::cmp::Ordering;
 
-    fn sort_output_deterministically(output: String) -> String {
+    fn sort_output_deterministically(output: &str) -> String {
         let mut lines: Vec<&str> = output.lines().collect();
 
         lines.sort_by(|left, right| {
@@ -123,7 +123,7 @@ weather_temperature_celsius{{version="{0}",source="org.example",location="My Nam
                 crate::config::VERSION
             ),
             sort_output_deterministically(
-                format(vec![Weather {
+                &format(vec![Weather {
                     source: "org.example".into(),
                     coordinates: Coordinates {
                         latitude: Coordinate::from(20.1),
@@ -156,7 +156,7 @@ weather_relative_humidity_ratio{{version="{0}",source="org.example",location="My
                 crate::config::VERSION
             ),
             sort_output_deterministically(
-                format(vec![Weather {
+                &format(vec![Weather {
                     source: "org.example".into(),
                     coordinates: Coordinates {
                         latitude: Coordinate::from(20.1),
@@ -191,7 +191,7 @@ weather_relative_humidity_ratio{{version="{0}",source="org.example",location="My
                 crate::config::VERSION
             ),
             sort_output_deterministically(
-                format(vec![
+                &format(vec![
                     Weather {
                         source: "org.example".into(),
                         coordinates: Coordinates {

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -77,6 +77,38 @@ mod tests {
     use crate::providers::units::{Celsius, Coordinate, Coordinates};
     use crate::providers::Weather;
     use assert_str::assert_str_eq;
+    use std::cmp::Ordering;
+
+    fn sort_output_deterministically(output: String) -> String {
+        let mut lines: Vec<&str> = output.lines().collect();
+
+        lines.sort_by(|left, right| {
+            let left_is_comment = left.starts_with("#");
+            let right_is_comment = right.starts_with("#");
+            let left_metric_id = get_metric_identifier(left, left_is_comment);
+            let right_metric_id = get_metric_identifier(right, right_is_comment);
+
+            // We only sort the metrics themselves and leave the rest untouched
+            if left_is_comment && right_is_comment || left_metric_id != right_metric_id {
+                return Ordering::Equal;
+            }
+
+            return left.partial_cmp(right).unwrap_or(Ordering::Equal);
+        });
+
+        lines.join("\n")
+    }
+
+    fn get_metric_identifier(line: &str, is_comment: bool) -> String {
+        if is_comment {
+            line.split(" ").nth(2).unwrap_or(&"".to_string()).into()
+        } else {
+            line.split("{")
+                .nth(0)
+                .expect("Could not extract identifier from metric line")
+                .into()
+        }
+    }
 
     #[test]
     fn format_single_temperature() {
@@ -90,18 +122,20 @@ weather_temperature_celsius{{version="{0}",source="org.example",location="My Nam
 "##,
                 crate::config::VERSION
             ),
-            format(vec![Weather {
-                source: "org.example".into(),
-                coordinates: Coordinates {
-                    latitude: Coordinate::from(20.1),
-                    longitude: Coordinate::from(10.01234),
-                },
-                location: "My Name".into(),
-                city: "Some City".into(),
-                temperature: Celsius::from(25.5),
-                relative_humidity: None
-            }])
-            .expect("Formatting should work")
+            sort_output_deterministically(
+                format(vec![Weather {
+                    source: "org.example".into(),
+                    coordinates: Coordinates {
+                        latitude: Coordinate::from(20.1),
+                        longitude: Coordinate::from(10.01234),
+                    },
+                    location: "My Name".into(),
+                    city: "Some City".into(),
+                    temperature: Celsius::from(25.5),
+                    relative_humidity: None
+                }])
+                .expect("Formatting should work")
+            )
         )
     }
 
@@ -121,42 +155,8 @@ weather_relative_humidity_ratio{{version="{0}",source="org.example",location="My
 "##,
                 crate::config::VERSION
             ),
-            format(vec![Weather {
-                source: "org.example".into(),
-                coordinates: Coordinates {
-                    latitude: Coordinate::from(20.1),
-                    longitude: Coordinate::from(10.01234),
-                },
-                location: "My Name".into(),
-                city: "Some City".into(),
-                temperature: Celsius::from(25.5),
-                relative_humidity: Some(Ratio(0.55))
-            }])
-            .expect("Formatting should work")
-        )
-    }
-
-    #[test]
-    #[ignore] // Sort order of metrics is not deterministic
-    fn format_multiple() {
-        assert_str_eq!(
-            format!(
-                r##"# HELP weather_temperature_celsius prometheus-weathermen temperature.
-# TYPE weather_temperature_celsius gauge
-# UNIT weather_temperature_celsius celsius
-weather_temperature_celsius{{version="{0}",source="org.example",location="My Name",city="Some City",latitude="20.1000004",longitude="10.0123396"}} 25.5
-weather_temperature_celsius{{version="{0}",source="com.example",location="Another Name",city="Another City",latitude="30.1000004",longitude="20.0123405"}} 15.5
-# HELP weather_relative_humidity_ratio prometheus-weathermen relative humidity.
-# TYPE weather_relative_humidity_ratio gauge
-# UNIT weather_relative_humidity_ratio ratio
-weather_relative_humidity_ratio{{version="{0}",source="org.example",location="My Name",city="Some City",latitude="20.1000004",longitude="10.0123396"}} 0.55
-weather_relative_humidity_ratio{{version="{0}",source="com.example",location="Another Name",city="Another City",latitude="30.1000004",longitude="20.0123405"}} 0.75
-# EOF
-"##,
-                crate::config::VERSION
-            ),
-            format(vec![
-                Weather {
+            sort_output_deterministically(
+                format(vec![Weather {
                     source: "org.example".into(),
                     coordinates: Coordinates {
                         latitude: Coordinate::from(20.1),
@@ -166,20 +166,57 @@ weather_relative_humidity_ratio{{version="{0}",source="com.example",location="An
                     city: "Some City".into(),
                     temperature: Celsius::from(25.5),
                     relative_humidity: Some(Ratio(0.55))
-                },
-                Weather {
-                    source: "com.example".into(),
-                    coordinates: Coordinates {
-                        latitude: Coordinate::from(30.1),
-                        longitude: Coordinate::from(20.01234),
+                }])
+                .expect("Formatting should work")
+            )
+        )
+    }
+
+    #[test]
+    fn format_multiple() {
+        assert_str_eq!(
+            format!(
+                r##"# HELP weather_temperature_celsius prometheus-weathermen temperature.
+# TYPE weather_temperature_celsius gauge
+# UNIT weather_temperature_celsius celsius
+weather_temperature_celsius{{version="{0}",source="com.example",location="Another Name",city="Another City",latitude="30.1000000",longitude="20.0123400"}} 15.5
+weather_temperature_celsius{{version="{0}",source="org.example",location="My Name",city="Some City",latitude="20.1000000",longitude="10.0123400"}} 25.5
+# HELP weather_relative_humidity_ratio prometheus-weathermen relative humidity.
+# TYPE weather_relative_humidity_ratio gauge
+# UNIT weather_relative_humidity_ratio ratio
+weather_relative_humidity_ratio{{version="{0}",source="com.example",location="Another Name",city="Another City",latitude="30.1000000",longitude="20.0123400"}} 0.75
+weather_relative_humidity_ratio{{version="{0}",source="org.example",location="My Name",city="Some City",latitude="20.1000000",longitude="10.0123400"}} 0.55
+# EOF
+"##,
+                crate::config::VERSION
+            ),
+            sort_output_deterministically(
+                format(vec![
+                    Weather {
+                        source: "org.example".into(),
+                        coordinates: Coordinates {
+                            latitude: Coordinate::from(20.1),
+                            longitude: Coordinate::from(10.01234),
+                        },
+                        location: "My Name".into(),
+                        city: "Some City".into(),
+                        temperature: Celsius::from(25.5),
+                        relative_humidity: Some(Ratio(0.55))
                     },
-                    location: "Another Name".into(),
-                    city: "Another City".into(),
-                    temperature: Celsius::from(15.5),
-                    relative_humidity: Some(Ratio(0.75))
-                }
-            ])
-            .expect("Formatting should work")
+                    Weather {
+                        source: "com.example".into(),
+                        coordinates: Coordinates {
+                            latitude: Coordinate::from(30.1),
+                            longitude: Coordinate::from(20.01234),
+                        },
+                        location: "Another Name".into(),
+                        city: "Another City".into(),
+                        temperature: Celsius::from(15.5),
+                        relative_humidity: Some(Ratio(0.75))
+                    }
+                ])
+                .expect("Formatting should work")
+            )
         )
     }
 }


### PR DESCRIPTION
Sort the metrics portion of the prometheus output deterministically so that the test can be unskipped.